### PR TITLE
style: Update taxonomies and post meta layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ public/tags/toc/index.xml
 .hugo_build.lock
 public/fonts/BricolageGrotesque\[opsz,wdth,wght].woff2
 public/js/bundle.min.js
+public/series/index.html
+public/series/index.xml
+public/series/finnal-piece/index.html
+public/series/finnal-piece/index.xml

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -251,10 +251,37 @@ menu a:hover {
 /* #endregion */
 
 /* #region ========== Post ========== */
+article {
+  max-width: var(--page-width);
+} 
+
 .summary p {
     margin-bottom: 1rem;
     font-variation-settings: "wght" 200;
     color: var(--foreground-alpha); 
+}
+
+.post-meta {
+  margin-bottom: 1rem;
+  color: var(--foreground-alpha);
+  font-variation-settings: "wght" 200;
+}
+
+.post-tags a {
+  margin-right: 0.3rem;
+}
+
+.series {
+  margin: 1.5rem 0;
+  padding: 0;
+  background-color: var(--theme-alpha);
+  border-radius: 4px;
+}
+
+.series p {
+  margin: 0;
+  padding: 0.5rem;
+  color: var(--foreground-alpha);
 }
 /* #endregion */
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -249,3 +249,29 @@ menu a:hover {
   transition: background-color 0.3s ease, color 0.3s ease;
 }
 /* #endregion */
+
+/* #region ========== Post ========== */
+.summary p {
+    margin-bottom: 1rem;
+    font-variation-settings: "wght" 200;
+    color: var(--foreground-alpha); 
+}
+/* #endregion */
+
+/* #region ========== Taxonomies Page ========== */
+.year-heading {
+  border-bottom: 1px dotted var(--foreground);
+}
+
+.post-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0;
+}
+
+.post-date {
+  margin: 0;
+  white-space: nowrap;
+}
+/* #endregion */

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -20,3 +20,6 @@ taxonomies:
   tag: "tags"
   series: "series"
   category: "categories"
+params:
+  dateFormat: "Jan 02, 2006"
+  enableSummary: false

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -16,3 +16,7 @@ module:
   hugoVersion:
     extended: false
     min: 0.116.0
+taxonomies:
+  tag: "tags"
+  series: "series"
+  category: "categories"

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -2,7 +2,7 @@
   
 <section>
   <h1>{{ .Title }}</h1>
-  <div class="summary">{{ .Content }}</div>
+  <p class="summary">{{ .Content }}</p>
 </section>
 
 <section>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,8 +1,25 @@
 {{ define "main" }}
+  
+<section>
   <h1>{{ .Title }}</h1>
-  {{ .Content }}
-  {{ range .Pages }}
-    <h2><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></h2>
-    {{ .Summary }}
+  <div class="summary">{{ .Content }}</div>
+</section>
+
+<section>
+  {{ range .Pages.GroupByDate "2006" }}
+  <section>
+    <h2 class="year-heading">
+      {{ .Key }}
+    </h2>
+
+    {{ range .Pages }}
+      <div class="post-item"> 
+        <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
+        <p class="post-date">{{ .Date.Format "Jan 02" }}</p>
+      </div>
+    {{ end }}
+  </section>
   {{ end }}
+</section>
+
 {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,10 +1,41 @@
 {{ define "main" }}
+<article>
   <h1>{{ .Title }}</h1>
 
-  {{ $dateMachine := .Date | time.Format "2006-01-02T15:04:05-07:00" }}
-  {{ $dateHuman := .Date | time.Format ":date_long" }}
-  <time datetime="{{ $dateMachine }}">{{ $dateHuman }}</time>
+  {{/* Summary */}}
+  {{ if and .Site.Params.enableSummary .Params.summary }}
+    <p class="summary">{{ .Params.summary }}</p>
+  {{ end }}
+
+  <div class="post-meta">
+    {{/* Published date */}}
+    {{ $dateMachine := .Date | time.Format "2006-01-02T15:04:05-07:00" }}
+    {{ $dateHuman := .Date | time.Format site.Params.dateFormat }}
+    <time datetime="{{ $dateMachine }}">{{ $dateHuman }}</time>
+  
+    {{/* Read time */}}
+    {{ if .ReadingTime }}
+      &nbsp; · &nbsp;
+      {{ .ReadingTime }} min read
+    {{ end }}
+  
+    {{/* Tags */}}
+    &nbsp; · &nbsp;
+    <span class="post-tags">
+      {{ partial "terms.html" (dict "taxonomy" "tags" "page" .) }}
+    </span>
+  </div>
+
+  {{/* Series */}}
+  {{- if .Params.series -}}
+  {{- with index (.GetTerms "series") 0 -}}
+    <div class="series">
+      <p>&#9432; This post is part of the <a href="{{ .Permalink }}" style="font-weight: bold">{{ .LinkTitle }}</a> series.</p>
+    </div>
+  {{- end -}}
+  {{- end -}}
 
   {{ .Content }}
-  {{ partial "terms.html" (dict "taxonomy" "tags" "page" .) }}
+
+</article>
 {{ end }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,0 +1,20 @@
+{{ define "main" }}
+
+<section>
+  <h1>{{ .Title }}</h1>
+  <div class="summary">{{ .Content }}</div>
+</section>
+
+<section>
+  <ul>
+    {{ $sortedPages := sort .Data.Pages "Title" }}
+    {{ range $sortedPages }}
+      <li>
+        <a href="{{ .Permalink }}">{{ .Title }}</a> 
+        {{ len .Pages }}
+      </li>
+    {{ end }}
+  </ul>
+</section>
+
+{{ end }}

--- a/layouts/partials/terms.html
+++ b/layouts/partials/terms.html
@@ -1,23 +1,19 @@
 {{- /*
-For a given taxonomy, renders a list of terms assigned to the page.
-
-@context {page} page The current page.
-@context {string} taxonomy The taxonomy.
-
-@example: {{ partial "terms.html" (dict "taxonomy" "tags" "page" .) }}
-*/}}
-
-{{- $page := .page }}
-{{- $taxonomy := .taxonomy }}
-
-{{- with $page.GetTerms $taxonomy }}
-  {{- $label := (index . 0).Parent.LinkTitle }}
-  <div>
-    <div>{{ $label }}:</div>
-    <ul>
-      {{- range . }}
-        <li><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></li>
-      {{- end }}
-    </ul>
-  </div>
-{{- end }}
+  For a given taxonomy, renders a list of terms assigned to the page.
+  
+  @context {page} page The current page.
+  @context {string} taxonomy The taxonomy.
+  
+  @example: {{ partial "terms.html" (dict "taxonomy" "tags" "page" .) }}
+  */}}
+  
+  {{- $page := .page }}
+  {{- $taxonomy := .taxonomy }}
+  
+  {{- with $page.GetTerms $taxonomy }}
+    {{- range . }}
+      <a href="{{ .RelPermalink }}">#{{ .LinkTitle }}</a>
+    {{- end }}
+  
+  {{- end }}
+  


### PR DESCRIPTION
- Configure Hugo taxonomies to include series.
- Update list page template to group posts by year.
- Add post meta information with date, reading time, and tags.
- Implement optional summary display.
- Add series notice for related posts.